### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include requirements.txt
+include setup.cfg
+include LICENSE


### PR DESCRIPTION
The requirements.txt is needed for setup execution and thus must be
included in the distribution. The other files are just nice to include
in a distribution... especially the license.
