### PR TITLE
ConsolePrinter: Ensure colorama initializes once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ src
 site
 .zanata-cache
 org.coala_analyzer.v1.service
+htmlcov
+.cache

--- a/pyprint/ConsolePrinter.py
+++ b/pyprint/ConsolePrinter.py
@@ -10,6 +10,7 @@ class ConsolePrinter(ColorPrinter):
 
     Note that pickling will not pickle the output member.
     """
+    colorama_initialized = False
 
     def __init__(self, print_colored=None):
         """
@@ -19,7 +20,9 @@ class ConsolePrinter(ColorPrinter):
                               colors if supported.
         """
         ColorPrinter.__init__(self, print_colored)
-        colorama.init()
+        if not ConsolePrinter.colorama_initialized:
+            colorama.init()
+            ConsolePrinter.colorama_initialized = True
 
     def _print_uncolored(self, output, **kwargs):
         print(output, end="")

--- a/tests/ConsolePrinterTest.py
+++ b/tests/ConsolePrinterTest.py
@@ -7,7 +7,9 @@ from pyprint.ContextManagers import retrieve_stdout
 class ConsolePrinterTest(unittest.TestCase):
 
     def test_printing(self):
+        self.assertEqual(ConsolePrinter.colorama_initialized, False)
         self.uut = ConsolePrinter(print_colored=True)
+        self.assertEqual(ConsolePrinter.colorama_initialized, True)
 
         with retrieve_stdout() as stdout:
             self.uut.print("\ntest", "message", color="green")
@@ -20,3 +22,6 @@ class ConsolePrinterTest(unittest.TestCase):
         with retrieve_stdout() as stdout:
             self.uut.print("\ntest", "message")
             self.assertEqual(stdout.getvalue(), "\ntest message\n")
+
+        self.uut = ConsolePrinter()
+        self.assertEqual(ConsolePrinter.colorama_initialized, True)


### PR DESCRIPTION
If colorama.init() is called multiple times, it crashes
and causes trouble. This ensures that it can only be
initialized once.

Fixes https://github.com/coala-analyzer/PyPrint/issues/23
