### PR TITLE
README: Use coala AppVeyor build

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Main authors and maintainers are:
 
 # STATUS
 
-[![Linux & OSX Build status](https://img.shields.io/travis/coala-analyzer/PyPrint/master.svg?label=linux%20and%20osx%20build)](https://travis-ci.org/coala-analyzer/PyPrint) [![Windows Build status](https://img.shields.io/appveyor/ci/sils1297/PyPrint/master.svg?label=windows%20build)](https://ci.appveyor.com/project/sils1297/PyPrint/branch/master)
+[![Linux & OSX Build status](https://img.shields.io/travis/coala-analyzer/PyPrint/master.svg?label=linux%20and%20osx%20build)](https://travis-ci.org/coala-analyzer/PyPrint) [![Windows Build status](https://img.shields.io/appveyor/ci/coala/PyPrint/master.svg?label=windows%20build)](https://ci.appveyor.com/project/coala/PyPrint/branch/master)
 
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/coala-analyzer/PyPrint.svg?label=scrutinizer quality)](https://scrutinizer-ci.com/g/coala-analyzer/PyPrint/?branch=master) [![codecov.io](https://img.shields.io/codecov/c/github/coala-analyzer/PyPrint/master.svg?label=branch coverage)](https://codecov.io/github/coala-analyzer/PyPrint?branch=master)
 


### PR DESCRIPTION
We moved AppVeyor to a new account so we're able to give
other people permission to cancel builds.
